### PR TITLE
Fix template-pack job runner to use Windows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -118,7 +118,7 @@ jobs:
           fi
 
   template-pack:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     needs: build-and-test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
The template-pack job was failing with exit code 127 because the nuget command is not available on Ubuntu runners. Changed the job to run on windows-latest where NuGet CLI is natively supported.