### PR TITLE
Fix template pack build and test issues

### DIFF
--- a/TestFrameworkBoilerplate.Template.nuspec
+++ b/TestFrameworkBoilerplate.Template.nuspec
@@ -34,7 +34,10 @@
     </releaseNotes>
   </metadata>
   <files>
+    <!-- README.md must be in package root for NuGet readme feature -->
+    <file src="README.md" target="" />
+    <!-- Include all other files in content folder for template -->
     <file src="**\*" target="content"
-          exclude="**\bin\**;**\obj\**;**\.vs\**;**\.git\**;**\.idea\**;**\*.user;**\*.suo;**\TestResults\**;**/node_modules/**" />
+          exclude="**\bin\**;**\obj\**;**\.vs\**;**\.git\**;**\.idea\**;**\*.user;**\*.suo;**\TestResults\**;**/node_modules/**;README.md" />
   </files>
 </package>


### PR DESCRIPTION
The README.md file must be placed in the package root (not in content folder) for NuGet to recognize it as the package readme file. This fixes the NU5039 error: "The readme file 'README.md' does not exist in the package."

Changes:
- Add explicit file entry for README.md with empty target (package root)
- Exclude README.md from wildcard pattern to avoid duplication
- Add comments explaining the README.md placement requirement